### PR TITLE
WIP Fixes for mdx-deck 3

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,13 +12,9 @@ module.exports = {
     {
       resolve: `gatsby-theme-mdx-deck`,
       options: {
-        // disable gatsby-mdx plugin – use this when your site already uses gatsby-mdx
-        mdx: false,
         // source directory for decks
         contentPath: `src/slides`,
         basePath: '/slides',
-        // name routes' basepath
-        name: `slides`,
       },
     },
     `gatsby-plugin-sass`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,9 +1769,9 @@
       }
     },
     "@mdx-deck/themes": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@mdx-deck/themes/-/themes-3.0.6.tgz",
-      "integrity": "sha512-xZNkDbeSqECMwKXh0RehqfMwfoQw4M96xLHaL5Dzkxki1DeXPP3I1vQExa9pFjwr6nR2nOzeUE5WlpjCuK6myw==",
+      "version": "3.0.8-alpha.2",
+      "resolved": "https://registry.npmjs.org/@mdx-deck/themes/-/themes-3.0.8-alpha.2.tgz",
+      "integrity": "sha512-Jsky7SA0HBkTw3xUHzw4obsYV9WHWIy1Bhauaz2fIyHem4QlIVUjKSDkSb7SRhR20Ofvfzna1fxbnUp9/eox5g==",
       "requires": {
         "lodash.merge": "^4.6.1",
         "react-syntax-highlighter": "^11.0.2"
@@ -9001,12 +9001,12 @@
       }
     },
     "gatsby-theme-mdx-deck": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-mdx-deck/-/gatsby-theme-mdx-deck-3.0.7.tgz",
-      "integrity": "sha512-MjzdlYIIfdKO9GsyRdAp4wbHliD65FluHhHSh9soYQUoklXu92GBKx5xpXCSIXAv5q0ghyo8ObhlUbtfpNmHug==",
+      "version": "3.0.8-alpha.2",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-mdx-deck/-/gatsby-theme-mdx-deck-3.0.8-alpha.2.tgz",
+      "integrity": "sha512-MpojwI7ixl32I50UF2lfuzB8imLePl7do7yZU8kc+V2GxbQ6x73f9B+dNHCr1RVwt3wgHBUPUGtEpzLXUFeGDw==",
       "requires": {
         "@emotion/core": "^10.0.14",
-        "@mdx-deck/themes": "^3.0.6",
+        "@mdx-deck/themes": "^3.0.8-alpha.2",
         "@mdx-js/mdx": "^1.0.21",
         "@mdx-js/react": "^1.0.21",
         "@reach/router": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gatsby-plugin-sharp": "^2.2.7",
     "gatsby-remark-prismjs": "^3.3.3",
     "gatsby-source-filesystem": "^2.1.5",
-    "gatsby-theme-mdx-deck": "^3.0.7",
+    "gatsby-theme-mdx-deck": "^3.0.8-alpha.2",
     "gatsby-transformer-sharp": "^2.2.3",
     "match-sorter": "^4.0.1",
     "node-sass": "^4.12.0",

--- a/src/components/site-chrome/counter.js
+++ b/src/components/site-chrome/counter.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useDeck } from 'gatsby-theme-mdx-deck'
 
 function AtTheBottomCenter ({ children }) {
   const css = {
@@ -16,8 +17,11 @@ function AtTheBottomCenter ({ children }) {
 }
 
 export default function Provider ({ children, ...props }) {
+  const deck = useDeck()
+  const { index, length } = deck
+
   return <>
     {children}
-    <AtTheBottomCenter>{props.index}/{props.slides.length}</AtTheBottomCenter>
+    <AtTheBottomCenter>{index}/{length}</AtTheBottomCenter>
   </>
 }

--- a/src/slides/index.mdx
+++ b/src/slides/index.mdx
@@ -1,18 +1,19 @@
-import CodeBlock from "../templates/code-figure"
+import CodeBlock from "../components/site-chrome/code-figure"
 import Slide from "../templates/slide"
 import ImageSlide from "../templates/image-slide"
 import AccessibleAnimationDemo from "../components/better/animation"
-// import highlight from '@mdx-deck/themes/syntax-highlighter-prism'
-// import Appear from "@mdx-deck/src/components/appear"
 import Autocomplete from "../components/better/downshift-autocomplete"
 import Dropdown from "../components/better/dropdown"
 
-import baseTheme from './theme'
+import baseTheme from '../theme'
+
 export const theme = baseTheme//, highlight]
-const openModal = () => {
+
+export const openModal = () => {
     document.querySelector('.modal-curtain').removeAttribute('hidden')
 }
-const buttonAction = () => {
+
+export const buttonAction = () => {
     alert('Button clicked')
 }
 
@@ -271,7 +272,7 @@ $ gatsby build && gatsby serve
 <CodeBlock side="left">
 
 ```css
-.visuallyhidden { 
+.visuallyhidden {
 	border: 0;
 	clip: rect(0 0 0 0);
 	height: 1px;
@@ -531,7 +532,7 @@ Expose accessibility information for focusable elements.
 ```html
 <div tabIndex="0"
      role="button"
-     aria-label="Close">   
+     aria-label="Close">
 </div>
 ```
 
@@ -544,7 +545,7 @@ Expose accessibility information for focusable elements.
 // focusable
 // a button widget, not a DIV
 // an accessible name
- 
+
 ```
 
 </CodeBlock>
@@ -579,7 +580,7 @@ Make custom controls fully interactive
      role="button"
      aria-label="Close"
      onClick={clickHandler}
-     onKeyDown={keydownHandler}>   
+     onKeyDown={keydownHandler}>
 </div>
 ```
 
@@ -591,7 +592,7 @@ Make custom controls fully interactive
 ```jsx
 // or just use a button :)
 <button aria-label="Close"
-        onClick={clickHandler}>   
+        onClick={clickHandler}>
 </button>
 ```
 
@@ -861,8 +862,8 @@ Navigation where JavaScript controls browser history<br />and dynamically maps U
 # Exercise
 ## Client-side routing demo
 
-- React: 
-- vanilla.js: 
+- React:
+- vanilla.js:
 
 </Slide>
 
@@ -1077,7 +1078,7 @@ var motionQuery = matchMedia('(prefers-reduced-motion)');
 function handleReduceMotionChanged() {
   if (motionQuery.matches) {
     /* adjust 'transition' or 'animation' properties */
-  } else { 
+  } else {
     /* standard motion */
   }
 }
@@ -1390,7 +1391,7 @@ context("Nav menu", () => {
 
 ```js
 const WebDriver = require('selenium-webdriver')
- 
+
 describe('Keyboard tests', () => {
     let driver = new selenium.Builder().forBrowser('chrome').build()
         driver.get('http://localhost:4000').then(() => done())

--- a/src/templates/slide.jsx
+++ b/src/templates/slide.jsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/core"
 import styled from "@emotion/styled"
 
 import SEO from "../components/site-chrome/seo"
-import theme from "../slides/theme"
+import theme from "../theme"
 
 const headerFooterStyles = css`
   background-color: ${theme.colors.headerFooterBackground};

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,4 +1,4 @@
-import Provider from './components/counter'
+import Provider from './components/site-chrome/counter'
 
 export default {
   css: {


### PR DESCRIPTION
It looked like `gatsby-plugin-mdx` might've been failing silently with some of the syntax in the MDX file, and `gatsby-theme-mdx-deck` was *not* properly handling `pathPrefix` – [PR here](https://github.com/jxnblk/mdx-deck/pull/422) 

- Updates imports based on where I think the modules are located (I might've mixed something up here)
- Removes JS comments from MDX – AFAIK comments that start with `//` are not supported in MDX
- Exports JS functions from MDX - without `export` at the beginning of the line, I don't think MDX parses that as JS